### PR TITLE
renovate/reconfigure

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,8 @@
     }
   ],
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
Add `helpers:pinGitHubActionDigestsToSemver` to renovate's extends list.

This ensures GitHub Action references are pinned to semver-compatible digests.